### PR TITLE
Add SPARK compatibility

### DIFF
--- a/src/resources.adb
+++ b/src/resources.adb
@@ -7,7 +7,7 @@ with System;
 
 with Interfaces.C;
 
-package body Resources is
+package body Resources with SPARK_Mode => Off is
 
    function WAI_getExecutablePath
      (Output      : System.Address;

--- a/src/resources.ads
+++ b/src/resources.ads
@@ -12,7 +12,7 @@ generic
    --  The default value provided here should work for all cases, i.e.
    --  when executables are installed in bin/ and libraries in lib/ or lib64/.
 
-package Resources is
+package Resources with SPARK_Mode => On is
 
    function Executable_Path return String;
    --  Return the absolute path to the running binary

--- a/tests/src/tests.adb
+++ b/tests/src/tests.adb
@@ -4,15 +4,21 @@ with Resources;
 with Lib_A;
 with Tests_Config;
 
-procedure Tests is
+procedure Tests with SPARK_Mode => On is
    package My_Resources is new Resources (Tests_Config.Crate_Name);
 
 begin
-   Put_Line ("Prefix_Path: " & My_Resources.Prefix_Path);
-   Put_Line ("Lib_A Prefix_Path: " & Lib_A.Resources.Prefix_Path);
+   Put ("Prefix_Path: ");
+   Put_Line (My_Resources.Prefix_Path);
 
-   Put_Line ("Test Resource_Path: " & My_Resources.Resource_Path);
-   Put_Line ("Lib_A Resource_Path: " & Lib_A.Resources.Resource_Path);
+   Put ("Lib_A Prefix_Path: ");
+   Put_Line (Lib_A.Resources.Prefix_Path);
+
+   Put ("Test Resource_Path: ");
+   Put_Line (My_Resources.Resource_Path);
+
+   Put ("Lib_A Resource_Path: ");
+   Put_Line (Lib_A.Resources.Resource_Path);
 
    Lib_A.Print_Content;
 end Tests;


### PR DESCRIPTION
Add SPARK_Mode annotations to make the crate usable in SPARK projects. The spec is marked with SPARK_Mode => On and the body with SPARK_Mode => Off, since the implementation relies on C FFI and other non-SPARK constructs.

Closes #3